### PR TITLE
chore: migrate to pnpm 12 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up pnpm native binary
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          standalone: true
+
       - name: Set up Vite+
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
@@ -65,6 +70,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Set up pnpm native binary
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          standalone: true
 
       - name: Set up Vite+
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0

--- a/package.json
+++ b/package.json
@@ -16,5 +16,5 @@
     "vite": "catalog:",
     "vite-plus": "catalog:"
   },
-  "packageManager": "pnpm@11.2.2"
+  "packageManager": "pnpm@12.0.0-beta.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,123 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0-beta.2
+        version: 12.0.0-beta.2
+      pnpm:
+        specifier: 12.0.0-beta.2
+        version: 12.0.0-beta.2
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-beta.2':
+    resolution: {integrity: sha512-AkIfunBjOPxt/T4BmtQbIMro0CErQiTr3H3UfiaP54guMF+0RKKe46briseecNQ6Vab7kvq8AifpTDyeYJUaBQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-beta.2':
+    resolution: {integrity: sha512-HMdm6Xi2+0ZFBJTTtYyAzTK9eQb8z5c7FdKo4347GM/gtAY6tY4ksdMlwAi0SVmMZGqerXuGxHE4Db6R2ptrDg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.2':
+    resolution: {integrity: sha512-/ot0+CnY9wT6GiKzAPiRt2nSPp4/BFAz33zOiwn0l4h5jouPKQVY4xWm6Kcs998KXBAor3WiRGM+2QMCjyNvuA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-beta.2':
+    resolution: {integrity: sha512-u7ydYC1+3fZgWdXMgVGEQGgr1CwMNLcVn3uzhmWxVmFvxywfqI77s7vubzOnv2S38vZIrH++8S19o0i+rkVX/Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-beta.2':
+    resolution: {integrity: sha512-oEDE8mC2XlEKjPLMaTl/82nNtsTK29f7ocrf+YHTIXRy+VlY7sCMuH4nUWP9g0TItVJVXPpsHi81FP4URTRmEA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-beta.2':
+    resolution: {integrity: sha512-wRfnA0fO06/5GZjBWy+stqQXMWWxmEQowtEE5/NvIJuRBzsIipaXLrPZRkbalnASPBXiESZqib3vbQmnkbSiYg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-beta.2':
+    resolution: {integrity: sha512-/zO1+iI2Trs2Bh5tjGtM5ctVpwqdh6jD2dBiYpekdvCIqDD7eHDDIjfYlgwT/Mu4emJ7aoiVxEFxjDg/eGwUWw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-beta.2':
+    resolution: {integrity: sha512-OHQpXeKHSLOmBVxKVTu7NYBKqVKI6X17SQrYyHGd7CMvzNc4A99/tKVjEIQmrAICDOGDR9I51JjZ6fNhXbDW/g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@pnpm/exe@12.0.0-beta.2':
+    resolution: {integrity: sha512-HIKoHFdZyPh6jx8lEP9IPur8wx93cyzpPdshn2oEWF5g4PZUAw/BOTUPS69HujAguux9V6ofXQ1VVR4XsmcMng==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+  pnpm@12.0.0-beta.2:
+    resolution: {integrity: sha512-v+W8TeaFKpHh8rmCra40ZGg4ZI9vNePguocwCaUX0fCeYBBcSrF9jCNJqi37ng4mDupmBKkCzmqpRbeUXHW0cw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-beta.2':
+    optional: true
+
+  '@pnpm/exe@12.0.0-beta.2':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-beta.2
+      '@pnpm/exe.darwin-x64': 12.0.0-beta.2
+      '@pnpm/exe.linux-arm64': 12.0.0-beta.2
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.2
+      '@pnpm/exe.linux-x64': 12.0.0-beta.2
+      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.2
+      '@pnpm/exe.win32-arm64': 12.0.0-beta.2
+      '@pnpm/exe.win32-x64': 12.0.0-beta.2
+
+  pnpm@12.0.0-beta.2:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-beta.2
+      '@pnpm/exe.darwin-x64': 12.0.0-beta.2
+      '@pnpm/exe.linux-arm64': 12.0.0-beta.2
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.2
+      '@pnpm/exe.linux-x64': 12.0.0-beta.2
+      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.2
+      '@pnpm/exe.win32-arm64': 12.0.0-beta.2
+      '@pnpm/exe.win32-x64': 12.0.0-beta.2
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Summary

Pin the workspace to pnpm 12.0.0-beta.2 and record pnpm 12 package-manager dependencies in the lockfile.

## Changes

- Updated `packageManager` from pnpm 11.2.2 to pnpm 12.0.0-beta.2.
- Regenerated `pnpm-lock.yaml` with pnpm 12.
- Bootstrapped the pnpm 12 native binary before Vite+ in verify and release jobs.

## Review aids

| Before | After |
| --- | --- |
| pnpm 11.2.2 | pnpm 12.0.0-beta.2 |

## Validation

- [x] pnpm 12 frozen install
- [x] `pnpm verify`: library and example checks, 77 tests, coverage, and both builds
- [x] Manual check not applicable; no product behavior changed

## Risks

- pnpm 12 is still a beta release.
- The lockfile now includes pnpm 12 package-manager environment metadata.

## Linked Items

- Org-wide uinaf pnpm 12 migration.