### PR TITLE
docs: add uinaf banner to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![react-json-logic — build and evaluate JsonLogic with React components.](https://uinaf.dev/og/banner/react-json-logic.png)
+
 # react-json-logic
 
 Build and evaluate [JsonLogic](http://jsonlogic.com) rules with React components.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![react-json-logic — build and evaluate JsonLogic with React components.](https://uinaf.dev/og/banner/react-json-logic.png)
+![](https://uinaf.dev/og/banner/react-json-logic.png)
 
 # react-json-logic
 


### PR DESCRIPTION
Adds the uinaf banner to the top of the README.

The image is generated at build time from this repo's own GitHub metadata (description, latest release, language, licence) and served from uinaf.dev, so it stays current without another PR here.

**Review aid:** https://uinaf.dev/og/banner/react-json-logic.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dynamic banner to the top of `README.md` for `react-json-logic`, generated from the repo’s metadata and served from uinaf.dev so it stays current. The image uses an empty alt attribute to avoid duplicating the title and description for screen readers.

<sup>Written for commit 3238b6719056deb133137983643e8444d3afddc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a banner image link at the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->