### PR TITLE
docs: document npm Trusted Publishing for releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,5 @@ pnpm exec vp run verify
 
 ## Release and Deployment Notes
 
-- On every push to `main` that is not tagged `[skip ci]`, CI runs `verify` and then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic` (Conventional Commits → version bump and npm publish, when applicable). The `NPM_TOKEN` secret must be set on the repository.
+- On every push to `main` that is not tagged `[skip ci]`, CI runs `verify` and then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic` (Conventional Commits → version bump and npm publish, when applicable). Publishing uses npm Trusted Publishing (OIDC): the release job grants `id-token: write` and does not use an `NPM_TOKEN` secret.
 - The demo app deploy is configured through the repository host dashboard


### PR DESCRIPTION
## Summary
- Align `CONTRIBUTING.md` with the existing release workflow, which already publishes via npm Trusted Publishing (OIDC) using `id-token: write`.
- Remove the stale requirement to set an `NPM_TOKEN` repository secret.

## Test plan
- [ ] Confirm `.github/workflows/ci.yml` release job still has `id-token: write` and no `NPM_TOKEN` / `NODE_AUTH_TOKEN` env.
- [ ] Skim CONTRIBUTING release notes for accuracy.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CONTRIBUTING to document npm Trusted Publishing (OIDC) for releases and remove the `NPM_TOKEN` requirement. CI publishes `packages/react-json-logic` via `semantic-release` using `id-token: write` with no token env.

<sup>Written for commit e6a6fef4c9cd96401f45fc0bd8cdacdd7b76965f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release documentation to reflect npm publishing through Trusted Publishing with OIDC.
  * Clarified that an `NPM_TOKEN` repository secret is no longer required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->