### PR TITLE
ci(release): attribute push-back to uinaf-releaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,13 @@ jobs:
       - verify
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment:
-      name: release
-      deployment: false
+    environment: release
     concurrency:
       group: release-${{ github.repository }}-main
       cancel-in-progress: false
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Check out repository
@@ -86,6 +82,24 @@ jobs:
         working-directory: packages/react-json-logic
         run: vp pack
 
+      - name: Create release bot token
+        id: release-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.UINAF_RELEASE_APP_ID }}
+          private-key: ${{ secrets.UINAF_RELEASE_APP_PRIVATE_KEY }}
+          owner: uinaf
+          repositories: |
+            react-json-logic
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Authorize release writes
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+        run: gh auth setup-git
+
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
@@ -98,8 +112,9 @@ jobs:
             @semantic-release/github@12.0.8
             conventional-changelog-conventionalcommits@9.3.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
+          GIT_COMMITTER_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: vp run verify
 
   release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.repository == 'uinaf/react-json-logic' && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
     name: Release react-json-logic
     needs:
       - verify
@@ -88,9 +88,8 @@ jobs:
         with:
           app-id: ${{ vars.UINAF_RELEASE_APP_ID }}
           private-key: ${{ secrets.UINAF_RELEASE_APP_PRIVATE_KEY }}
-          owner: uinaf
-          repositories: |
-            react-json-logic
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-issues: write
           permission-pull-requests: write
@@ -99,6 +98,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: gh auth setup-git
+
+      # GitHub links bot commits when the noreply email uses `{user-id}+{slug}[bot]@…`.
+      - name: Resolve release bot identity
+        id: release-bot-identity
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
@@ -115,6 +122,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: 312581908+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         run: vp run verify
 
   release:
-    if: github.repository == 'uinaf/react-json-logic' && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip ci]')
     name: Release react-json-logic
     needs:
       - verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,5 +44,5 @@ pnpm exec vp run verify
 
 ## Release and Deployment Notes
 
-- On every push to `main` that is not tagged `[skip ci]`, CI runs `verify` and then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic` (Conventional Commits → version bump and npm publish, when applicable). Publishing uses npm Trusted Publishing (OIDC): the release job grants `id-token: write` and does not use an `NPM_TOKEN` secret.
+- On every push to `main` that is not tagged `[skip ci]`, CI runs `verify` and then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic` (Conventional Commits → version bump and npm publish, when applicable). Publishing uses npm Trusted Publishing (OIDC): the release job grants `id-token: write` and does not use an `NPM_TOKEN` secret. GitHub Release and version push-back commits are authored by `uinaf-releaser[bot]` via a short-lived App installation token from the `release` Environment.
 - The demo app deploy is configured through the repository host dashboard


### PR DESCRIPTION
## Summary
- Mint short-lived `uinaf-releaser` tokens for semantic-release git/GitHub writes
- Attribute bump commits to `uinaf-releaser[bot]` instead of `github-actions[bot]`
- Keep npm Trusted Publishing (OIDC); drop invalid `deployment: false`

## Test plan
- [x] Seed `release` Environment with `UINAF_RELEASE_APP_ID` + `UINAF_RELEASE_APP_PRIVATE_KEY`
- [ ] Verify CI on this PR
- [ ] After merge, next releasable push shows bump author `uinaf-releaser[bot]`

## Review aids
```mermaid
flowchart LR
  build[vp pack] --> mint[create-github-app-token]
  mint --> auth[gh auth setup-git]
  auth --> sr[semantic-release]
  sr --> npmOidc[npm OIDC publish]
  sr --> pushback[git bump as uinaf-releaser]
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release writes to a short-lived GitHub App token so version bump commits and GitHub Releases are authored by `uinaf-releaser[bot]` instead of `github-actions[bot]`. Keep npm Trusted Publishing (OIDC) and reduce default job permissions.

- **Refactors**
  - Scope the App token to the current owner/repo from GitHub context; rely on the `release` Environment (no hard-coded canonical repo gate).
  - Mint the token via `actions/create-github-app-token` and run `gh auth setup-git` before `semantic-release`.
  - Resolve the bot user ID at runtime and set GIT author/committer noreply email to link `uinaf-releaser[bot]` commits; use the token for `GITHUB_TOKEN`/`GH_TOKEN`.
  - Restrict job `permissions` to `contents: read` (keep `id-token: write`); use the app token for contents/issues/PR writes in `cycjimmy/semantic-release-action`; update CONTRIBUTING to note bot authorship.

<sup>Written for commit 91ad41e324f2c16bf05631d07c600e50a8758da7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

