### PR TITLE
ci(release): fix bot identity lookup quoting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
-        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
+            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
+            exit 1
+          fi
+          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
 
       - name: Release package
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0


### PR DESCRIPTION
## Summary
- Fix nested-quote breakage in runtime bot user-id lookup
- Fail the step if the resolved id is not numeric

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bot user ID lookup in the release workflow by switching to a multiline shell step to avoid nested-quote issues. The step now validates the `gh` response and fails if the ID is not numeric, preventing misconfigured releases.

<sup>Written for commit 7b430344aac519e0c05474b23880c6508d0eaa44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

