### PR TITLE
ci: deny workflow permissions by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add workflow-level `permissions: {}`

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deny all GitHub Actions permissions by default by adding workflow-level `permissions: {}` in `ci.yml`. This hardens CI and requires jobs to explicitly request only the scopes they need.

- **Migration**
  - Add job-level `permissions` for any job that needs `GITHUB_TOKEN` (e.g., `contents: read`).
  - Specify other scopes explicitly when required (e.g., `id-token: write`).

<sup>Written for commit 3b7452d9eb9622bbd26c38cc97c9b1143a977fdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow security by restricting default automation permissions.
  * Individual jobs must now explicitly request the access they need.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->