### PR TITLE
fix: sign semantic-release version commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
         id: release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
+          semantic_version: 25.0.3
           extra_plugins: |
             @semantic-release/commit-analyzer@13.0.1
             @semantic-release/release-notes-generator@14.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,36 +101,25 @@ jobs:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: gh auth setup-git
 
-      # GitHub links bot commits when the noreply email uses `{user-id}+{slug}[bot]@…`.
-      - name: Resolve release bot identity
-        id: release-bot-identity
-        env:
-          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
-          APP_SLUG: ${{ steps.release-bot.outputs.app-slug }}
-        run: |
-          set -euo pipefail
-          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
-          if [[ ! "$user_id" =~ ^[0-9]+$ ]]; then
-            echo "failed to resolve numeric bot user id for ${APP_SLUG}[bot]" >&2
-            exit 1
-          fi
-          echo "user-id=${user_id}" >> "$GITHUB_OUTPUT"
-
       - name: Release package
+        id: release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         with:
-          working_directory: packages/react-json-logic
           extra_plugins: |
             @semantic-release/commit-analyzer@13.0.1
             @semantic-release/release-notes-generator@14.1.1
             @semantic-release/npm@13.1.5
-            @semantic-release/git@10.0.1
+            @jno21/semantic-release-github-commit@1.0.1
             @semantic-release/github@12.0.8
             conventional-changelog-conventionalcommits@9.3.1
         env:
           GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
-          GIT_AUTHOR_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_AUTHOR_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: ${{ steps.release-bot.outputs.app-slug }}[bot]
-          GIT_COMMITTER_EMAIL: ${{ steps.release-bot-identity.outputs.user-id }}+${{ steps.release-bot.outputs.app-slug }}[bot]@users.noreply.github.com
+
+      - name: Verify immutable release
+        if: steps.release.outputs.new_release_published == 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.new_release_git_tag }}
+        run: |
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq .immutable)" = true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "repositoryUrl": "https://github.com/uinaf/react-json-logic.git",
   "tagFormat": "v${version}",
   "plugins": [
     [
@@ -17,14 +18,15 @@
     [
       "@semantic-release/npm",
       {
+        "pkgRoot": "packages/react-json-logic",
         "npmPublish": true
       }
     ],
     [
-      "@semantic-release/git",
+      "@jno21/semantic-release-github-commit",
       {
-        "assets": ["package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "files": ["packages/react-json-logic/package.json"],
+        "commitMessage": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary

Move release orchestration to the repository root so the nested package version can be committed through GitHub as a signed App commit before publication.

## Changes

- move semantic-release configuration to the repository root
- keep npm publication scoped to packages/react-json-logic with pkgRoot
- replace semantic-release/git with @jno21/semantic-release-github-commit@1.0.1
- remove manual bot identity setup
- verify that the GitHub Release is immutable

## Validation

- [x] pnpm verify
- [x] actionlint
- [x] semantic-release 25.0.3 dry run loaded the root config, nested npm plugin, and signed commit plugin

## Risks

The first merged release is the runtime proof. The root config is required because the GitHub commit plugin uses repository-root paths.

## Linked Items

Runtime pattern already proven by uinaf/design v1.7.1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign version bump commits as a GitHub App using `@jno21/semantic-release-github-commit`. Publishing stays scoped to `packages/react-json-logic`.

- **Refactors**
  - Move `.releaserc` to the repo root; add `repositoryUrl`; keep `@semantic-release/npm` with `"pkgRoot": "packages/react-json-logic"`.
  - Replace `@semantic-release/git` with `@jno21/semantic-release-github-commit` to sign commits to `packages/react-json-logic/package.json`.
  - CI: run `semantic-release` from the root, pin `semantic-release` to 25.0.3, remove manual bot identity, and verify GitHub releases are immutable.

<sup>Written for commit dd14b32b750ea17a0a50e4b9dc23d645680b225e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

