### PR TITLE
fix: treat non-object data JSON as a parse error

### DIFF
--- a/packages/react-json-logic/src/components/json-logic-builder.tsx
+++ b/packages/react-json-logic/src/components/json-logic-builder.tsx
@@ -36,7 +36,11 @@ export function JsonLogicBuilder({
   const parseResult = useMemo<ParseResult>(() => {
     if (typeof data !== "string") return { ok: true, data };
     try {
-      return { ok: true, data: JSON.parse(data) as JsonLogicData };
+      const parsed: unknown = JSON.parse(data);
+      if (parsed !== null && typeof parsed === "object") {
+        return { ok: true, data: parsed as JsonLogicData };
+      }
+      return { ok: false, error: new Error("data must be an object or array"), raw: data };
     } catch (error) {
       return { ok: false, error, raw: data };
     }

--- a/packages/react-json-logic/tests/edge-cases.test.tsx
+++ b/packages/react-json-logic/tests/edge-cases.test.tsx
@@ -104,6 +104,16 @@ describe("edge cases — accessor / data shape", () => {
     expect(container.querySelector("[data-rjl-accessor]")).toBeNull();
   });
 
+  test("primitive JSON data string is recovered to empty object", () => {
+    const onChange = vi.fn();
+    const onDataError = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value="" data={"null"} onDataError={onDataError} />,
+    );
+    expect(onDataError).toHaveBeenCalled();
+    expect(container.querySelector("[data-rjl-builder]")).not.toBeNull();
+  });
+
   test("invalid JSON data string is recovered to empty object", () => {
     const onChange = vi.fn();
     const onDataError = vi.fn();

--- a/packages/react-json-logic/tests/json-logic-builder.test.tsx
+++ b/packages/react-json-logic/tests/json-logic-builder.test.tsx
@@ -536,6 +536,48 @@ describe("<JsonLogicBuilder /> — error surfacing", () => {
     expect(onDataError.mock.calls[1]?.[1]).toBe("{bad");
   });
 
+  test("calls onDataError when data JSON parses to null", () => {
+    const onChange = vi.fn();
+    const onDataError = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} data="null" onDataError={onDataError} />,
+    );
+    expect(onDataError).toHaveBeenCalledTimes(1);
+    expect(onDataError.mock.calls[0]?.[1]).toBe("null");
+    expect(container.querySelector("[data-rjl-builder]")).not.toBeNull();
+  });
+
+  test("calls onDataError when data JSON parses to a number", () => {
+    const onChange = vi.fn();
+    const onDataError = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} data="42" onDataError={onDataError} />,
+    );
+    expect(onDataError).toHaveBeenCalledTimes(1);
+    expect(onDataError.mock.calls[0]?.[1]).toBe("42");
+    expect(container.querySelector("[data-rjl-builder]")).not.toBeNull();
+  });
+
+  test("calls onDataError when data JSON parses to a boolean", () => {
+    const onChange = vi.fn();
+    const onDataError = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} data="true" onDataError={onDataError} />,
+    );
+    expect(onDataError).toHaveBeenCalledTimes(1);
+    expect(onDataError.mock.calls[0]?.[1]).toBe("true");
+    expect(container.querySelector("[data-rjl-builder]")).not.toBeNull();
+  });
+
+  test("warns to console when data JSON is a primitive and no onDataError is given", () => {
+    const onChange = vi.fn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { container } = render(<JsonLogicBuilder onChange={onChange} data="null" />);
+    expect(warn).toHaveBeenCalled();
+    expect(container.querySelector("[data-rjl-builder]")).not.toBeNull();
+    warn.mockRestore();
+  });
+
   test("does not fire onDataError twice for the same persistent malformed data", () => {
     const onChange = vi.fn();
     const onDataError = vi.fn();


### PR DESCRIPTION
## Summary
- `JSON.parse("null")` / `"42"` / `"true"` succeeded, then `Object.keys` threw during render.
- Those results now take the existing `onDataError` / `console.warn` path and the builder stays mounted.

## Test plan
- [x] `vp test json-logic-builder edge-cases` — `data="null"` / `"42"` / `"true"` fire `onDataError` and do not throw
- [x] `vp check`