### PR TITLE
fix: walk array literals and check non-array arity in validate

### DIFF
--- a/packages/react-json-logic/src/validator.ts
+++ b/packages/react-json-logic/src/validator.ts
@@ -23,14 +23,47 @@ export function validate(rule: unknown): ValidationResult {
   return errors.length === 0 ? { ok: true } : { ok: false, errors };
 }
 
-function walk(node: unknown, path: string, errors: ValidationError[]): void {
-  if (node === null || typeof node !== "object" || Array.isArray(node)) return;
+function pushArityErrors(
+  op: (typeof OPERATORS)[number],
+  key: string,
+  path: string,
+  argCount: number,
+  errors: ValidationError[],
+): void {
+  if (argCount < op.fieldCount.min) {
+    errors.push({
+      path: `${path}.${key}`,
+      message: `${key}: expected at least ${op.fieldCount.min} arg(s), got ${argCount}`,
+    });
+  }
+  if (argCount > op.fieldCount.max) {
+    errors.push({
+      path: `${path}.${key}`,
+      message: `${key}: expected at most ${op.fieldCount.max} arg(s), got ${argCount}`,
+    });
+  }
+}
+
+function walk(
+  node: unknown,
+  path: string,
+  errors: ValidationError[],
+  isArrayElement = false,
+): void {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => walk(item, `${path}[${i}]`, errors, true));
+    return;
+  }
 
   const obj = node as Record<string, unknown>;
   const keys = Object.keys(obj);
 
   if (keys.length === 0) return;
   if (keys.length > 1) {
+    // json-logic-js preserves multi-key objects inside arrays as literal
+    // records rather than interpreting them as operator objects.
+    if (isArrayElement) return;
     errors.push({
       path,
       message: `Operator object should have exactly one key, found ${keys.length}: ${keys.join(", ")}`,
@@ -51,24 +84,15 @@ function walk(node: unknown, path: string, errors: ValidationError[]): void {
   const args = obj[key];
 
   if (Array.isArray(args)) {
-    if (op) {
-      if (args.length < op.fieldCount.min) {
-        errors.push({
-          path: `${path}.${key}`,
-          message: `${key}: expected at least ${op.fieldCount.min} arg(s), got ${args.length}`,
-        });
-      }
-      if (args.length > op.fieldCount.max) {
-        errors.push({
-          path: `${path}.${key}`,
-          message: `${key}: expected at most ${op.fieldCount.max} arg(s), got ${args.length}`,
-        });
-      }
-    }
-    args.forEach((arg, i) => walk(arg, `${path}.${key}[${i}]`, errors));
-  } else {
-    // Some json-logic operators (e.g. var) accept a non-array shorthand.
-    // Only flag if a known operator explicitly requires an array.
-    walk(args, `${path}.${key}`, errors);
+    if (op) pushArityErrors(op, key, path, args.length, errors);
+    args.forEach((arg, i) => walk(arg, `${path}.${key}[${i}]`, errors, true));
+    return;
   }
+
+  // json-logic-js treats a non-array payload as a single argument.
+  // `var` is the documented string-path shorthand and is not arity-flagged.
+  if (op && key !== "var") {
+    pushArityErrors(op, key, path, 1, errors);
+  }
+  walk(args, `${path}.${key}`, errors);
 }

--- a/packages/react-json-logic/tests/validator.test.ts
+++ b/packages/react-json-logic/tests/validator.test.ts
@@ -62,4 +62,57 @@ describe("validate", () => {
   test("tolerates the => wrapper used by the higher-order UI", () => {
     expect(validate({ "=>": [{ "===": [1, 1] }] })).toEqual({ ok: true });
   });
+
+  test("walks operator objects inside array literals", () => {
+    const topLevel = validate([{ "===": [1] }]);
+    expect(topLevel.ok).toBe(false);
+    if (!topLevel.ok) {
+      expect(topLevel.errors[0]?.path).toBe("$[0].===");
+      expect(topLevel.errors[0]?.message).toMatch(/at least 2/);
+    }
+
+    const nested = validate({ in: ["x", [{ "===": [1] }]] });
+    expect(nested.ok).toBe(false);
+    if (!nested.ok) {
+      expect(nested.errors[0]?.path).toBe("$.in[1][0].===");
+      expect(nested.errors[0]?.message).toMatch(/at least 2/);
+    }
+  });
+
+  test("accepts record literals inside arrays", () => {
+    expect(validate([{ id: 1, name: "one" }])).toEqual({ ok: true });
+    expect(
+      validate({
+        map: [[{ id: 1, name: "one" }], { var: "id" }],
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  test("flags non-array payloads that violate arity", () => {
+    const eq = validate({ "===": 1 });
+    expect(eq.ok).toBe(false);
+    if (!eq.ok) {
+      expect(eq.errors[0]?.message).toMatch(/at least 2/);
+    }
+
+    const and = validate({ and: true });
+    expect(and.ok).toBe(false);
+    if (!and.ok) {
+      expect(and.errors[0]?.message).toMatch(/at least 2/);
+    }
+  });
+
+  test("still accepts the var string shorthand", () => {
+    expect(validate({ var: "a" })).toEqual({ ok: true });
+  });
+
+  test("walks a nested operator inside a non-array payload", () => {
+    const result = validate({ "!": { "===": [1] } });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.path).toBe("$.!.===");
+      expect(result.errors[0]?.message).toMatch(/at least 2/);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- `validate()` skipped array nodes, so `{ in: ["x", [{ "===": [1] }]] }` returned `{ ok: true }`.
- Non-array payloads were never arity-checked, so `{ "===": 1 }` and `{ and: true }` passed.
- `{ var: "a" }` stays valid (documented json-logic-js shorthand).

## Test plan
- [x] `vp test validator edge-cases`
- [x] `vp check`