### PR TITLE
fix: render json-logic var string shorthand in the accessor

### DIFF
--- a/packages/react-json-logic/src/components/any.tsx
+++ b/packages/react-json-logic/src/components/any.tsx
@@ -96,7 +96,7 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
   const updateChildArray = (update: (arr: JsonLogicValue[]) => JsonLogicValue[]) => {
     const current = isPlainObject(value) ? value : {};
     const slot = current[field];
-    const arr = Array.isArray(slot) ? [...slot] : [];
+    const arr = Array.isArray(slot) ? [...slot] : typeof slot === "string" ? [slot] : [];
     onChange({ ...current, [field]: update(arr) });
   };
 
@@ -127,8 +127,9 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
     if (field === "value") {
       childValue = value ?? "";
     } else if (isPlainObject(value)) {
-      const arr = value[field];
-      if (Array.isArray(arr)) childValue = arr[index] ?? "";
+      const slot = value[field];
+      if (Array.isArray(slot)) childValue = slot[index] ?? "";
+      else if (typeof slot === "string" && index === 0) childValue = slot;
     }
 
     const childOnChange = (val: JsonLogicValue) => onChildValueChange(val, index);

--- a/packages/react-json-logic/tests/json-logic-builder.test.tsx
+++ b/packages/react-json-logic/tests/json-logic-builder.test.tsx
@@ -245,6 +245,18 @@ describe("<JsonLogicBuilder /> — render paths", () => {
     expect(container.querySelector("[data-rjl-accessor]")).not.toBeNull();
   });
 
+  test("renders the var string shorthand path in the accessor", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value={{ var: "a.b" }} data={{ a: { b: 1 } }} />,
+    );
+    expect(container.querySelector("[data-rjl-accessor]")).not.toBeNull();
+    const inputs = container.querySelectorAll("[data-rjl-accessor-input]");
+    expect(inputs.length).toBeGreaterThanOrEqual(2);
+    expect((inputs[0] as HTMLInputElement).value).toBe("a");
+    expect((inputs[1] as HTMLInputElement).value).toBe("b");
+  });
+
   test("accepts a JSON string for data", () => {
     const onChange = vi.fn();
     const { container } = render(
@@ -491,6 +503,20 @@ describe("<JsonLogicBuilder /> — interaction (onChange)", () => {
     const last = onChange.mock.calls.at(-1)?.[0] as Record<string, JsonLogicValue>;
     // the var operator carries an array of [path] (or [path, fallback])
     expect(last.var).toEqual(["alp"]);
+  });
+
+  test("editing a var string shorthand normalizes to the array form", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <StatefulHost initial={{ var: "alpha" }} data={{ alpha: 1, beta: 2 }} onChange={onChange} />,
+    );
+    const accessorInput = container.querySelector("[data-rjl-accessor-input]") as HTMLInputElement;
+    expect(accessorInput).not.toBeNull();
+    expect(accessorInput.value).toBe("alpha");
+    fireEvent.change(accessorInput, { target: { value: "beta" } });
+    expect(onChange).toHaveBeenCalled();
+    const last = onChange.mock.calls.at(-1)?.[0] as Record<string, JsonLogicValue>;
+    expect(last.var).toEqual(["beta"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `{ var: "user.age" }` is a valid spec shape that `validate()` already accepts.
- The UI only read array slots, so the path rendered empty and the first keystroke overwrote it.
- First edit normalizes to `{ var: ["…"] }`, matching `rule.var`.

## Test plan
- [x] Render `{ var: "a.b" }` shows both path segments
- [x] Editing `{ var: "alpha" }` emits `{ var: ["beta"] }`
- [x] Empty `data` still hides `var`