### PR TITLE
feat: edit boolean, null, and array literals in the value field

### DIFF
--- a/packages/react-json-logic/README.md
+++ b/packages/react-json-logic/README.md
@@ -76,28 +76,31 @@ Each factory returns a `JsonLogicValue` shaped per the canonical [JsonLogic](htt
 
 Components render unstyled. Target the rendered DOM via stable `data-rjl-*` attributes:
 
-| Attribute                       | What it marks                                      |
-| ------------------------------- | -------------------------------------------------- |
-| `data-rjl-builder`              | Outermost wrapper                                  |
-| `data-rjl-any`                  | Recursive operator container                       |
-| `data-rjl-children`             | Wrapper around an operator's child fields          |
-| `data-rjl-field`                | A single child field row                           |
-| `data-rjl-add`                  | "Add field" button                                 |
-| `data-rjl-remove`               | "Remove field" button                              |
-| `data-rjl-operator-trigger`     | Operator dropdown trigger                          |
-| `data-rjl-operator-popup`       | Operator dropdown popup (portaled)                 |
-| `data-rjl-input`                | Value-input wrapper                                |
-| `data-rjl-input-type-trigger`   | Type select trigger (`text` / `number`)            |
-| `data-rjl-input-type-popup`     | Type select popup (portaled)                       |
-| `data-rjl-input-value`          | The actual `<input>` element                       |
-| `data-rjl-accessor`             | Accessor (`var`) wrapper                           |
-| `data-rjl-accessor-level`       | One level of an accessor path                      |
-| `data-rjl-accessor-level-index` | The level's index (`"0"`, `"1"`, …)                |
-| `data-rjl-accessor-input`       | Accessor input element                             |
-| `data-rjl-accessor-popup`       | Accessor suggestion popup (portaled)               |
-| `data-rjl-higher-order`         | `some` / `all` / `none` / `map` / `filter` wrapper |
-| `data-rjl-higher-order-arrow`   | The `=>` glyph                                     |
-| `data-rjl-higher-order-child`   | The inner expression of a higher-order op          |
+| Attribute                       | What it marks                                                          |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `data-rjl-builder`              | Outermost wrapper                                                      |
+| `data-rjl-any`                  | Recursive operator container                                           |
+| `data-rjl-children`             | Wrapper around an operator's child fields                              |
+| `data-rjl-field`                | A single child field row                                               |
+| `data-rjl-add`                  | "Add field" button                                                     |
+| `data-rjl-remove`               | "Remove field" button                                                  |
+| `data-rjl-operator-trigger`     | Operator dropdown trigger                                              |
+| `data-rjl-operator-popup`       | Operator dropdown popup (portaled)                                     |
+| `data-rjl-input`                | Value-input wrapper                                                    |
+| `data-rjl-input-type-trigger`   | Type select trigger (`text` / `number` / `boolean` / `null` / `array`) |
+| `data-rjl-input-type-popup`     | Type select popup (portaled)                                           |
+| `data-rjl-input-value`          | The text/number `<input>`, or the array `<textarea>`                   |
+| `data-rjl-input-boolean`        | Boolean `true` / `false` select trigger                                |
+| `data-rjl-input-boolean-popup`  | Boolean `true` / `false` select popup (portaled)                       |
+| `data-rjl-input-array`          | Array-literal `<textarea>`                                             |
+| `data-rjl-accessor`             | Accessor (`var`) wrapper                                               |
+| `data-rjl-accessor-level`       | One level of an accessor path                                          |
+| `data-rjl-accessor-level-index` | The level's index (`"0"`, `"1"`, …)                                    |
+| `data-rjl-accessor-input`       | Accessor input element                                                 |
+| `data-rjl-accessor-popup`       | Accessor suggestion popup (portaled)                                   |
+| `data-rjl-higher-order`         | `some` / `all` / `none` / `map` / `filter` wrapper                     |
+| `data-rjl-higher-order-arrow`   | The `=>` glyph                                                         |
+| `data-rjl-higher-order-child`   | The inner expression of a higher-order op                              |
 
 Example with Tailwind:
 

--- a/packages/react-json-logic/src/components/any.tsx
+++ b/packages/react-json-logic/src/components/any.tsx
@@ -125,10 +125,10 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
 
     let childValue: JsonLogicValue = "";
     if (field === "value") {
-      childValue = value ?? "";
+      childValue = value === undefined ? "" : value;
     } else if (isPlainObject(value)) {
       const slot = value[field];
-      if (Array.isArray(slot)) childValue = slot[index] ?? "";
+      if (Array.isArray(slot)) childValue = slot[index] === undefined ? "" : slot[index];
       else if (typeof slot === "string" && index === 0) childValue = slot;
     }
 
@@ -143,7 +143,13 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
         element = (
           <Input
             value={
-              typeof childValue === "string" || typeof childValue === "number" ? childValue : ""
+              typeof childValue === "string" ||
+              typeof childValue === "number" ||
+              typeof childValue === "boolean" ||
+              childValue === null ||
+              Array.isArray(childValue)
+                ? childValue
+                : ""
             }
             onChange={childOnChange}
           />

--- a/packages/react-json-logic/src/components/input.tsx
+++ b/packages/react-json-logic/src/components/input.tsx
@@ -1,13 +1,19 @@
 import { Select } from "@base-ui/react/select";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import type { JsonLogicValue } from "../operators.ts";
 
-const INPUT_TYPES = ["text", "number"] as const;
+const INPUT_TYPES = ["text", "number", "boolean", "null", "array"] as const;
 type InputType = (typeof INPUT_TYPES)[number];
+
+const BOOLEAN_ITEMS = [
+  { label: "true", value: "true" },
+  { label: "false", value: "false" },
+] as const;
 
 interface Props {
   name?: string;
-  value?: string | number;
-  /** Initial type fallback if `value` is a string. Ignored if `value` is a number. */
+  value?: JsonLogicValue;
+  /** Initial type fallback if `value` is a string. Ignored for number/boolean/null/array. */
   type?: InputType;
   /**
    * Called with the next value. Note: when the input type is `"number"` and
@@ -16,13 +22,106 @@ interface Props {
    * `NaN`. Consumers that store the result into a numeric field should
    * coerce or validate at the boundary.
    */
-  onChange: (value: string | number) => void;
+  onChange: (value: JsonLogicValue) => void;
 }
 
-const isNumeric = (value: unknown): value is number => typeof value === "number";
+const getType = (value: JsonLogicValue | undefined, fallback: InputType): InputType => {
+  if (typeof value === "number" && Number.isFinite(value)) return "number";
+  if (typeof value === "boolean") return "boolean";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return fallback;
+};
 
-const getType = (value: unknown, fallback: InputType): InputType =>
-  isNumeric(value) ? "number" : fallback;
+const toText = (value: JsonLogicValue | undefined): string => {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+};
+
+const toBoolean = (value: JsonLogicValue | undefined): boolean =>
+  value === true || value === "true" || value === 1;
+
+const toArray = (value: JsonLogicValue | undefined): JsonLogicValue[] => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      // unparseable text becomes an empty array
+    }
+  }
+  return [];
+};
+
+interface ArrayEditorState {
+  draft: string;
+  serializedValue: string;
+  pendingValue: string | null;
+}
+
+function ArrayEditor({
+  name,
+  value,
+  onChange,
+}: {
+  name: string;
+  value: JsonLogicValue[];
+  onChange: (value: JsonLogicValue[]) => void;
+}) {
+  const serialized = JSON.stringify(value);
+  const [editor, setEditor] = useState<ArrayEditorState>(() => ({
+    draft: serialized,
+    serializedValue: serialized,
+    pendingValue: null,
+  }));
+  if (serialized !== editor.serializedValue) {
+    const isAcknowledgement = editor.pendingValue === serialized;
+    setEditor({
+      draft: isAcknowledgement ? editor.draft : serialized,
+      serializedValue: serialized,
+      pendingValue: null,
+    });
+  }
+
+  const onDraftChange = (raw: string) => {
+    let emitted: JsonLogicValue[] | undefined;
+    if (raw.trim() === "") {
+      emitted = [];
+    } else {
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (Array.isArray(parsed)) emitted = parsed;
+      } catch {
+        // keep drafting until the JSON is a valid array
+      }
+    }
+    const emittedSerialized = emitted === undefined ? undefined : JSON.stringify(emitted);
+    setEditor((current) => {
+      const pendingValue =
+        emittedSerialized === undefined
+          ? current.pendingValue
+          : emittedSerialized === current.serializedValue
+            ? null
+            : emittedSerialized;
+      return { ...current, draft: raw, pendingValue };
+    });
+    if (emitted !== undefined) onChange(emitted);
+  };
+
+  return (
+    <textarea
+      name={name}
+      aria-label={name || "Array value"}
+      data-rjl-input-array
+      data-rjl-input-value
+      value={editor.draft}
+      onChange={(e) => onDraftChange(e.target.value)}
+    />
+  );
+}
 
 export function Input({ name = "", value = "", type: typeProp = "text", onChange }: Props) {
   // Type is a pure derivation of (value, typeProp) — no useState/useEffect
@@ -33,13 +132,24 @@ export function Input({ name = "", value = "", type: typeProp = "text", onChange
 
   const onTypeChange = (next: InputType | null) => {
     if (!next) return;
-    if (next === "number") {
-      const n = parseFloat(String(value));
-      // Guard against `NaN` flowing back through the controlled input —
-      // unparseable input becomes 0 rather than the literal string "NaN".
-      onChange(Number.isFinite(n) ? n : 0);
-    } else {
-      onChange(String(value));
+    switch (next) {
+      case "number": {
+        const n = parseFloat(toText(value));
+        onChange(Number.isFinite(n) ? n : 0);
+        return;
+      }
+      case "text":
+        onChange(toText(value));
+        return;
+      case "boolean":
+        onChange(toBoolean(value));
+        return;
+      case "null":
+        onChange(null);
+        return;
+      case "array":
+        onChange(toArray(value));
+        return;
     }
   };
 
@@ -80,13 +190,48 @@ export function Input({ name = "", value = "", type: typeProp = "text", onChange
         </Select.Portal>
       </Select.Root>
 
-      <input
-        name={name}
-        value={String(value)}
-        type={type}
-        onChange={onValueChange}
-        data-rjl-input-value
-      />
+      {(type === "text" || type === "number") && (
+        <input
+          name={name}
+          aria-label={name || "Value"}
+          value={typeof value === "string" || typeof value === "number" ? String(value) : ""}
+          type={type}
+          onChange={onValueChange}
+          data-rjl-input-value
+        />
+      )}
+
+      {type === "boolean" && (
+        <Select.Root
+          items={[...BOOLEAN_ITEMS]}
+          value={value === true ? "true" : "false"}
+          onValueChange={(next) => {
+            if (next == null) return;
+            onChange(next === "true");
+          }}
+        >
+          <Select.Trigger data-rjl-input-boolean>
+            <Select.Value />
+          </Select.Trigger>
+          <Select.Portal>
+            <Select.Positioner>
+              <Select.Popup data-rjl-input-boolean-popup>
+                <Select.List>
+                  {BOOLEAN_ITEMS.map(({ label, value: itemValue }) => (
+                    <Select.Item key={itemValue} value={itemValue}>
+                      <Select.ItemText>{label}</Select.ItemText>
+                    </Select.Item>
+                  ))}
+                </Select.List>
+              </Select.Popup>
+            </Select.Positioner>
+          </Select.Portal>
+        </Select.Root>
+      )}
+
+      {type === "array" && (
+        <ArrayEditor name={name} value={Array.isArray(value) ? value : []} onChange={onChange} />
+      )}
     </span>
   );
 }

--- a/packages/react-json-logic/tests/edge-cases.test.tsx
+++ b/packages/react-json-logic/tests/edge-cases.test.tsx
@@ -28,10 +28,12 @@ describe("edge cases — value shapes", () => {
     expect(container.querySelectorAll("[data-rjl-field]").length).toBe(0);
   });
 
-  test("null value is tolerated and renders the value field", () => {
+  test("null value is tolerated and renders the null type", () => {
     const onChange = vi.fn();
     const { container } = render(<JsonLogicBuilder onChange={onChange} value={null} />);
-    expect(container.querySelector("input[data-rjl-input-value]")).not.toBeNull();
+    expect(container.querySelector("[data-rjl-input-type-trigger]")).not.toBeNull();
+    expect(container.querySelector("input[data-rjl-input-value]")).toBeNull();
+    expect(container.querySelector("[data-rjl-input-array]")).toBeNull();
   });
 
   test("number-typed value renders a number input", () => {
@@ -41,18 +43,19 @@ describe("edge cases — value shapes", () => {
     expect(input.type).toBe("number");
   });
 
-  test("boolean-shaped values fall through to the value field", () => {
+  test("boolean-shaped values render a boolean control", () => {
     const onChange = vi.fn();
-    const { container } = render(
-      <JsonLogicBuilder onChange={onChange} value={true as unknown as string} />,
-    );
-    expect(container.querySelector("input[data-rjl-input-value]")).not.toBeNull();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={true} />);
+    expect(container.querySelector("[data-rjl-input-boolean]")).not.toBeNull();
+    expect(container.querySelector("input[data-rjl-input-value]")).toBeNull();
   });
 
-  test("array-shaped value falls through to the value field", () => {
+  test("array-shaped values render an array editor", () => {
     const onChange = vi.fn();
     const { container } = render(<JsonLogicBuilder onChange={onChange} value={[1, 2, 3]} />);
-    expect(container.querySelector("input[data-rjl-input-value]")).not.toBeNull();
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    expect(editor).not.toBeNull();
+    expect(JSON.parse(editor.value)).toEqual([1, 2, 3]);
   });
 
   test("renders a deeply nested rule (10+ levels)", () => {

--- a/packages/react-json-logic/tests/json-logic-builder.test.tsx
+++ b/packages/react-json-logic/tests/json-logic-builder.test.tsx
@@ -312,6 +312,36 @@ describe("<JsonLogicBuilder /> — render paths", () => {
     expect(screen.getAllByText("or").length).toBeGreaterThan(0);
   });
 
+  test("preserves boolean literals inside and", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value={{ and: [true, false] }} />,
+    );
+    const bools = container.querySelectorAll("[data-rjl-input-boolean]");
+    expect(bools.length).toBe(2);
+    expect(container.querySelectorAll("input[data-rjl-input-value]").length).toBe(0);
+  });
+
+  test("preserves null literals inside operator arguments", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value={{ and: [null, true] }} />,
+    );
+    const inputs = container.querySelectorAll("[data-rjl-input]");
+    const nullType = inputs[0]?.querySelector("[data-rjl-input-type-trigger]");
+    expect(nullType?.textContent).toBe("null");
+  });
+
+  test("preserves an array haystack on in", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value={{ in: ["a", ["a", "b"]] }} />,
+    );
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    expect(editor).not.toBeNull();
+    expect(JSON.parse(editor.value)).toEqual(["a", "b"]);
+  });
+
   test("renders comparison operators", () => {
     const onChange = vi.fn();
     for (const op of ["<", "<=", ">", ">="] as const) {
@@ -389,6 +419,7 @@ describe("<JsonLogicBuilder /> — interaction (onChange)", () => {
     const onChange = vi.fn();
     const { container } = render(<JsonLogicBuilder onChange={onChange} value="" />);
     const input = container.querySelector("input[data-rjl-input-value]") as HTMLInputElement;
+    expect(input.getAttribute("aria-label")).toBe("Value");
     fireEvent.change(input, { target: { value: "hello" } });
     expect(onChange).toHaveBeenCalled();
     expect(onChange.mock.calls.at(-1)?.[0]).toBe("hello");
@@ -463,6 +494,189 @@ describe("<JsonLogicBuilder /> — interaction (onChange)", () => {
     const textOption = within(popup).getByRole("option", { name: "text" });
     await user.click(textOption);
     expect(onChange.mock.calls.at(-1)?.[0]).toBe("42");
+  });
+
+  test("opening the input-type dropdown and picking 'boolean' emits false", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value="" />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "boolean" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(false);
+  });
+
+  test("picking false on a boolean value emits false", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={true} />);
+    const boolTrigger = container.querySelector("[data-rjl-input-boolean]") as HTMLElement;
+    expect(boolTrigger).not.toBeNull();
+    await user.click(boolTrigger);
+    const popup = await screen.findByRole("listbox");
+    expect(popup.closest("[data-rjl-input-boolean-popup]")).not.toBeNull();
+    expect(popup.closest("[data-rjl-input-type-popup]")).toBeNull();
+    await user.click(within(popup).getByRole("option", { name: "false" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe(false);
+  });
+
+  test("editing an array literal textarea emits the parsed array", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <JsonLogicBuilder onChange={onChange} value={[] as JsonLogicValue} />,
+    );
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    expect(editor).not.toBeNull();
+    expect(editor.getAttribute("aria-label")).toBe("Array value");
+    fireEvent.change(editor, { target: { value: "[1,2]" } });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([1, 2]);
+  });
+
+  test("clearing the array editor emits an empty array", () => {
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "" } });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([]);
+  });
+
+  test("invalid JSON in the array editor does not emit", () => {
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "[1," } });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(editor.value).toBe("[1,");
+  });
+
+  test("opening the input-type dropdown and picking 'null' emits null", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value="" />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "null" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toBeNull();
+  });
+
+  test("opening the input-type dropdown and picking 'array' emits []", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value="" />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "array" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([]);
+  });
+
+  test("switching an array value to text stringifies it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={[1, 2]} />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "text" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("[1,2]");
+  });
+
+  test("switching a boolean value to text stringifies it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value={true} />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "text" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toBe("true");
+  });
+
+  test("switching non-array text to array emits []", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value="hello" />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "array" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([]);
+  });
+
+  test("switching a JSON-array string to array parses it", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { container } = render(<JsonLogicBuilder onChange={onChange} value="[1,2]" />);
+    const typeTrigger = container.querySelector("[data-rjl-input-type-trigger]") as HTMLElement;
+    await user.click(typeTrigger);
+    const popup = await screen.findByRole("listbox");
+    await user.click(within(popup).getByRole("option", { name: "array" }));
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([1, 2]);
+  });
+
+  test("array editor resyncs when the controlled value changes", () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    expect(JSON.parse(editor.value)).toEqual([1]);
+    rerender(<JsonLogicBuilder onChange={onChange} value={[2, 3]} />);
+    const next = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    expect(JSON.parse(next.value)).toEqual([2, 3]);
+  });
+
+  test("keeps a newer array draft when the parent acknowledges an earlier edit", () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "[1,2]" } });
+    expect(onChange.mock.calls.at(-1)?.[0]).toEqual([1, 2]);
+
+    fireEvent.change(editor, { target: { value: "[1,2," } });
+    rerender(<JsonLogicBuilder onChange={onChange} value={[1, 2]} />);
+
+    expect(editor.value).toBe("[1,2,");
+  });
+
+  test("resyncs an external array value after an equivalent local edit", () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "[ 1 ]" } });
+    fireEvent.change(editor, { target: { value: "[2]" } });
+    rerender(<JsonLogicBuilder onChange={onChange} value={[2]} />);
+
+    fireEvent.change(editor, { target: { value: "[2," } });
+    rerender(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+
+    expect(editor.value).toBe("[1]");
+  });
+
+  test("resyncs after a local edit returns to the controlled array value", () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "[2]" } });
+    fireEvent.change(editor, { target: { value: "[1]" } });
+    fireEvent.change(editor, { target: { value: "[1," } });
+
+    rerender(<JsonLogicBuilder onChange={onChange} value={[2]} />);
+
+    expect(editor.value).toBe("[2]");
+  });
+
+  test("resyncs when an external value matches a superseded local edit", () => {
+    const onChange = vi.fn();
+    const { container, rerender } = render(<JsonLogicBuilder onChange={onChange} value={[0]} />);
+    const editor = container.querySelector("[data-rjl-input-array]") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: "[1]" } });
+    fireEvent.change(editor, { target: { value: "[2]" } });
+    fireEvent.change(editor, { target: { value: "[2," } });
+
+    rerender(<JsonLogicBuilder onChange={onChange} value={[1]} />);
+
+    expect(editor.value).toBe("[1]");
   });
 
   test("switching to number with non-numeric value emits 0 (NaN guard)", async () => {


### PR DESCRIPTION
## Summary
- The value UI only knew text and number, so `{ and: [true, false] }` and `{ in: ["a", ["a", "b"]] }` showed empty inputs.
- Type chooser now includes `boolean`, `null`, and `array`.
- Array editor uses a local draft so mid-JSON keystrokes do not fight the cursor.

## Test plan
- [x] `vp test --coverage` (thresholds still met)
- [x] `vp check`
- [ ] Click through boolean / null / array in the example app