### PR TITLE
fix: export types and document the React 19 peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Build and evaluate [JsonLogic](http://jsonlogic.com) rules with React components
 pnpm add react-json-logic react react-dom
 ```
 
+Requires React 19 (`react` / `react-dom` peer `^19.0.0`).
+
 ## Basic Usage
 
 ```tsx
@@ -35,7 +37,7 @@ function Example() {
 
 - Default export: `JsonLogicBuilder`
 - Named exports: `applyLogic`, `rule`, `validate`, `OPERATORS`, `FIELD_TYPES`
-- Core types: `JsonLogicValue`, `JsonLogicData`, `ValidationResult`, `ValidationError`
+- Core types: `JsonLogicBuilderProps`, `JsonLogicValue`, `JsonLogicData`, `ValidationResult`, `ValidationError`
 
 ### Component Props
 

--- a/packages/react-json-logic/README.md
+++ b/packages/react-json-logic/README.md
@@ -10,6 +10,8 @@ Build and evaluate [JsonLogic](http://jsonlogic.com) rules with React components
 pnpm add react-json-logic react react-dom
 ```
 
+Requires React 19 (`react` / `react-dom` peer `^19.0.0`).
+
 ## Usage
 
 ```tsx
@@ -43,7 +45,7 @@ values. `JsonLogicData = Record<string, unknown> | unknown[]` is the
 narrower shape the `data` prop accepts (objects or arrays — primitives
 make no sense as accessor data).
 
-Named exports: `applyLogic`, `rule`, `validate`, `OPERATORS`, `FIELD_TYPES`, types `FieldType`, `Operator`, `JsonLogicValue`, `JsonLogicData`, `ValidationError`, `ValidationResult`.
+Named exports: `applyLogic`, `rule`, `validate`, `OPERATORS`, `FIELD_TYPES`, types `JsonLogicBuilderProps`, `FieldType`, `Operator`, `JsonLogicValue`, `JsonLogicData`, `ValidationError`, `ValidationResult`.
 
 ## Building rules in code
 

--- a/packages/react-json-logic/package.json
+++ b/packages/react-json-logic/package.json
@@ -25,6 +25,7 @@
     "dist"
   ],
   "type": "module",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": "./dist/index.mjs",
     "./package.json": "./package.json"


### PR DESCRIPTION
## Summary
- Published `3.0.3` shipped `dist/index.d.mts` but no `types` field.
- `vp pack` flattens `exports["."]` to a string, so types are advertised via top-level `"types": "./dist/index.d.mts"`.
- Both READMEs state the existing `react` / `react-dom` `^19.0.0` peer. No peer-range or 19.2.8 bump.

## Test plan
- [x] `vp pack` leaves the `types` field in place
- [x] `vp check` in the library and example app