### PR TITLE
docs: strip em dashes, fill the banner alt, use the house H1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ packages/react-json-logic/
     builder.ts                     # typed `rule` factory
     validator.ts                   # `validate()`
     components/
-      json-logic-builder.tsx       # default export — top-level controlled wrapper
+      json-logic-builder.tsx       # default export: top-level controlled wrapper
       any.tsx                      # recursive operator dispatcher
       input.tsx                    # value field (Base UI Select for type chooser)
       accessor.tsx                 # var/accessor field (Base UI Autocomplete)
@@ -62,7 +62,7 @@ All filenames are kebab-case.
 
 - **Headless.** No CSS shipped. Style via `data-rjl-*` attributes documented in the README. Keep CSS modules out of the library.
 - **Base UI for primitives.** Operator/type dropdowns use `Select` from `@base-ui/react/select`. The accessor field uses `Autocomplete` from `@base-ui/react/autocomplete`. Both render through portals.
-- **Controlled components.** `props.onChange` is the source of truth — no internal `useState` mirror for `value`.
+- **Controlled components.** `props.onChange` is the source of truth; no internal `useState` mirror for `value`.
 - **Coverage gate** is enforced in `packages/react-json-logic/vite.config.ts`. Run `pnpm exec vp test --coverage` (or `pnpm verify`) to evaluate.
 - **Public API is small on purpose.** Default export `JsonLogicBuilder`, plus `applyLogic`, `rule`, `validate`, `OPERATORS`, `FIELD_TYPES`, and the core types. Adding a new public export is an API decision, not a casual change.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![](https://uinaf.dev/og/banner/react-json-logic.png)
+![react-json-logic — build and evaluate JsonLogic with React components.](https://uinaf.dev/og/banner/react-json-logic.png)
 
-# react-json-logic
+# uinaf/react-json-logic
 
 Build and evaluate [JsonLogic](http://jsonlogic.com) rules with React components.
 

--- a/packages/react-json-logic/README.md
+++ b/packages/react-json-logic/README.md
@@ -33,12 +33,12 @@ function Example() {
 
 ## Props
 
-| Prop          | Type                                  | Default        | Description                                                                                                                |
-| ------------- | ------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `onChange`    | `(value: JsonLogicValue) => void`     | none           | Called with the updated rule whenever the builder changes.                                                                 |
-| `value`       | `JsonLogicValue`                      | `""`           | Current rule (controlled).                                                                                                 |
+| Prop          | Type                                  | Default        | Description                                                                                                               |
+| ------------- | ------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `onChange`    | `(value: JsonLogicValue) => void`     | none           | Called with the updated rule whenever the builder changes.                                                                |
+| `value`       | `JsonLogicValue`                      | `""`           | Current rule (controlled).                                                                                                |
 | `data`        | `JsonLogicData \| string`             | `{}`           | Sample data, used by accessor (`var`) field suggestions. Pass an object/array directly or a JSON string (parsed for you). |
-| `onDataError` | `(err: unknown, raw: string) => void` | `console.warn` | Called when `data` is a string and `JSON.parse` fails. De-duplicated by raw value, fires once per malformed input.         |
+| `onDataError` | `(err: unknown, raw: string) => void` | `console.warn` | Called when `data` is a string and `JSON.parse` fails. De-duplicated by raw value, fires once per malformed input.        |
 
 `JsonLogicValue` is the recursive any-shape type for rules and primitive
 values. `JsonLogicData = Record<string, unknown> | unknown[]` is the

--- a/packages/react-json-logic/README.md
+++ b/packages/react-json-logic/README.md
@@ -2,7 +2,7 @@
 
 Build and evaluate [JsonLogic](http://jsonlogic.com) rules with React components.
 
-**Headless.** No CSS shipped — bring your own. Built on [Base UI](https://base-ui.com) primitives. Style with Tailwind, CSS modules, vanilla CSS, or whatever you like.
+**Headless.** No CSS shipped; bring your own. Built on [Base UI](https://base-ui.com) primitives. Style with Tailwind, CSS modules, vanilla CSS, or whatever you like.
 
 ## Install
 
@@ -35,14 +35,14 @@ function Example() {
 
 | Prop          | Type                                  | Default        | Description                                                                                                                |
 | ------------- | ------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `onChange`    | `(value: JsonLogicValue) => void`     | —              | Called with the updated rule whenever the builder changes.                                                                 |
+| `onChange`    | `(value: JsonLogicValue) => void`     | none           | Called with the updated rule whenever the builder changes.                                                                 |
 | `value`       | `JsonLogicValue`                      | `""`           | Current rule (controlled).                                                                                                 |
-| `data`        | `JsonLogicData \| string`             | `{}`           | Sample data — used by accessor (`var`) field suggestions. Pass an object/array directly or a JSON string (parsed for you). |
+| `data`        | `JsonLogicData \| string`             | `{}`           | Sample data, used by accessor (`var`) field suggestions. Pass an object/array directly or a JSON string (parsed for you). |
 | `onDataError` | `(err: unknown, raw: string) => void` | `console.warn` | Called when `data` is a string and `JSON.parse` fails. De-duplicated by raw value, fires once per malformed input.         |
 
 `JsonLogicValue` is the recursive any-shape type for rules and primitive
 values. `JsonLogicData = Record<string, unknown> | unknown[]` is the
-narrower shape the `data` prop accepts (objects or arrays — primitives
+narrower shape the `data` prop accepts (objects or arrays; primitives
 make no sense as accessor data).
 
 Named exports: `applyLogic`, `rule`, `validate`, `OPERATORS`, `FIELD_TYPES`, types `JsonLogicBuilderProps`, `FieldType`, `Operator`, `JsonLogicValue`, `JsonLogicData`, `ValidationError`, `ValidationResult`.
@@ -60,7 +60,7 @@ applyLogic(r, { user: { age: 21 }, score: 150 }); // → true
 validate(r); // → { ok: true }
 ```
 
-Each factory returns a `JsonLogicValue` shaped per the canonical [JsonLogic](http://jsonlogic.com) spec — the `<JsonLogicBuilder />` UI, `applyLogic`, and `validate` all consume the same shape. Arity is enforced at the function signature level (no runtime schema overhead).
+Each factory returns a `JsonLogicValue` shaped per the canonical [JsonLogic](http://jsonlogic.com) spec; the `<JsonLogicBuilder />` UI, `applyLogic`, and `validate` all consume the same shape. Arity is enforced at the function signature level (no runtime schema overhead).
 
 | Group        | Factories                                                            |
 | ------------ | -------------------------------------------------------------------- |
@@ -72,7 +72,7 @@ Each factory returns a `JsonLogicValue` shaped per the canonical [JsonLogic](htt
 | String/Array | `in(needle, haystack)`, `cat(...args)`, `merge(...args)`             |
 | Higher-order | `some`, `all`, `none`, `map`, `filter`                               |
 
-`validate(rule)` walks a rule against the operator table and reports structural problems (multi-key operator objects, arity violations, etc.) as `{ ok: false, errors: [{ path, message }] }`. Custom operators (registered via `json-logic-js`'s `add_operation`) are tolerated — only known operators get arity-checked.
+`validate(rule)` walks a rule against the operator table and reports structural problems (multi-key operator objects, arity violations, etc.) as `{ ok: false, errors: [{ path, message }] }`. Custom operators (registered via `json-logic-js`'s `add_operation`) are tolerated; only known operators get arity-checked.
 
 ## Styling
 


### PR DESCRIPTION
## Problem

The banner image has empty alt text, the H1 (`# react-json-logic`) misses the house form, and 8 em dashes sit across AGENTS.md and the package README (one as a bare table placeholder).

## Solution

- Banner alt becomes `react-json-logic — build and evaluate JsonLogic with React components.` (the one sanctioned em dash).
- H1 becomes `# uinaf/react-json-logic`; clauses take semicolons; the default-column placeholder reads `none`.
- Alongside this PR, the repository description moved to the brand register (lowercase lead).

Part of the house gauntlet ([ffsstack#53](https://github.com/uinaf/ffsstack/issues/53)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)