### PR TITLE
ci: adopt the shared scan baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 1
+      default-days: 7
     groups:
       npm-patch-minor:
         update-types: ["patch", "minor"]
@@ -22,7 +22,7 @@ updates:
     schedule:
       interval: monthly
     cooldown:
-      default-days: 1
+      default-days: 7
     groups:
       actions-patch-minor:
         update-types: ["patch", "minor"]

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,21 @@
+name: Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    uses: uinaf/.github/.github/workflows/scan.yml@main

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -9,8 +9,7 @@ on:
     - cron: "23 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: scan-${{ github.workflow }}-${{ github.ref }}
@@ -18,4 +17,6 @@ concurrency:
 
 jobs:
   scan:
+    permissions:
+      contents: read
     uses: uinaf/.github/.github/workflows/scan.yml@main

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track main by design; version and
+        # digest bumps land once in uinaf/.github for every adopter.
+        "uinaf/*": ref-pin
+        "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,5 +4,5 @@ rules:
       policies:
         # First-party reusable workflows track main by design; version and
         # digest bumps land once in uinaf/.github for every adopter.
-        "uinaf/*": ref-pin
+        "uinaf/.github": ref-pin
         "*": hash-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,5 +4,5 @@ rules:
       policies:
         # First-party reusable workflows track main by design; version and
         # digest bumps land once in uinaf/.github for every adopter.
-        "uinaf/.github": ref-pin
+        "uinaf/.github/*": ref-pin
         "*": hash-pin

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+# Survey fixture data; "question_key" fields are identifiers, not credentials.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "example survey fixtures"
+paths = [
+  '''examples/constants/question.json''',
+]


### PR DESCRIPTION
## Problem

No secret scanning or workflow lint runs here.

## Solution

A thin caller for the shared `workflow_call` scan in [uinaf/.github](https://github.com/uinaf/.github/blob/main/.github/workflows/scan.yml) (gitleaks, trufflehog, actionlint, zizmor; digest-pinned there, bumped once for every adopter), plus the zizmor policy allowing first-party refs while keeping hash pins for everything else. Pattern piloted green on [healthd#57](https://github.com/uinaf/healthd/pull/57); part of [ffsstack#53](https://github.com/uinaf/ffsstack/issues/53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)