### PR TITLE
docs: hold the docs to the house style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing
 
-Thanks for improving this repository.
-
 ## Scope
 
 - `packages/react-json-logic`: publishable library package
@@ -39,10 +37,13 @@ pnpm exec vp run verify
 
 - Use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`)
 - Keep each pull request focused on one concern
-- Fill out the pull request template
+- Fill out the [pull request template](https://github.com/uinaf/.github/blob/main/PULL_REQUEST_TEMPLATE.md)
 - Include validation evidence (at minimum `pnpm verify`)
 
 ## Release and Deployment Notes
 
-- On every push to `main` that is not tagged `[skip ci]`, CI runs `verify` and then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic` (Conventional Commits → version bump and npm publish, when applicable). Publishing uses npm Trusted Publishing (OIDC): the release job grants `id-token: write` and does not use an `NPM_TOKEN` secret. GitHub Release and version push-back commits are authored by `uinaf-releaser[bot]` via a short-lived App installation token from the `release` Environment.
+- On every push to `main` without `[skip ci]` in the commit message, CI runs `verify`, then [semantic-release](https://github.com/semantic-release/semantic-release) for `packages/react-json-logic`
+- Conventional Commits drive the version bump and npm publish, when applicable
+- Publishing uses npm Trusted Publishing (OpenID Connect): the release job grants `id-token: write` and uses no `NPM_TOKEN` secret
+- GitHub Releases and version push-back commits are authored by `uinaf-releaser[bot]` via a short-lived App installation token from the `release` Environment
 - The demo app deploy is configured through the repository host dashboard

--- a/README.md
+++ b/README.md
@@ -48,20 +48,7 @@ function Example() {
 
 ## Styling
 
-Use stable `data-rjl-*` attributes to style the rendered DOM (for example with Tailwind, CSS Modules, or vanilla CSS).
-
-Common hooks include:
-
-- `data-rjl-builder`
-- `data-rjl-any`
-- `data-rjl-field`
-- `data-rjl-add`
-- `data-rjl-remove`
-- `data-rjl-operator-trigger`
-- `data-rjl-operator-popup`
-- `data-rjl-input-value`
-- `data-rjl-accessor-input`
-- `data-rjl-higher-order`
+Use stable `data-rjl-*` attributes to style the rendered DOM (for example with Tailwind, CSS Modules, or vanilla CSS). The full attribute table is in the [package README](packages/react-json-logic/README.md#styling).
 
 ## Building Rules in Code
 
@@ -83,17 +70,9 @@ This repository is a workspace with:
 - `packages/react-json-logic` (publishable npm package)
 - `apps/example` (demo app)
 
-From the workspace root:
-
-```bash
-pnpm install --frozen-lockfile
-pnpm verify
-pnpm dev:example
-```
-
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+Setup, workflow, and release notes: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,7 @@
 
 ## Reporting a Vulnerability
 
-Please report vulnerabilities privately by emailing `dev@uinaf.dev`.
-
-Use private email for suspected security problems.
+Report vulnerabilities privately by emailing `dev@uinaf.dev`. Do not disclose suspected vulnerabilities in public issues.
 
 ## What to Include
 

--- a/packages/react-json-logic/README.md
+++ b/packages/react-json-logic/README.md
@@ -133,7 +133,7 @@ pnpm exec vp pack               # build the library
 pnpm verify       # the full gate (check + test --coverage + pack)
 ```
 
-See [AGENTS.md](AGENTS.md) for project layout and contributor notes.
+See [AGENTS.md](https://github.com/uinaf/react-json-logic/blob/main/AGENTS.md) for project layout and contributor notes.
 
 ## License
 


### PR DESCRIPTION
The root README duplicated the package README's styling attribute list and CONTRIBUTING's setup commands, and a few doc lines drifted from the repo.

- **Spec:** the house writing style (outcome first, one fact per line, bullets over paragraphs, links over code spans).
- **Applied:** root README points at the package README for the `data-rjl-*` table and at CONTRIBUTING for setup; the release paragraph in CONTRIBUTING became 4 one-fact bullets; SECURITY reporting tightened to one line; greeting filler dropped.
- **Fixed:** the package README linked `AGENTS.md` relatively, which breaks on npm; it now links the repo copy. The stale "fill out the pull request template" line is restored as a link to the org template, which does exist.
- **Verified:** `vp fmt --check` clean on all 40 files except a pre-existing `.gitleaks.toml` issue this branch does not touch; every doc link target resolves; `CLAUDE.md` already symlinks `AGENTS.md`.
