### PR TITLE
fix: preserve imported operands and supported arities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   verify:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     name: Verify workspace
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
@@ -47,7 +47,8 @@ jobs:
     name: Release react-json-logic
     needs:
       - verify
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # npm trusted publishing requires GitHub-hosted runners.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: release
     concurrency:

--- a/apps/example/src/app.tsx
+++ b/apps/example/src/app.tsx
@@ -18,6 +18,10 @@ const SAMPLE_DATA = {
 
 const SAMPLES: Array<{ title: string; rule: JsonLogicValue }> = [
   { title: "empty", rule: "" },
+  { title: "imported unary number", rule: { "-": 5 } },
+  { title: "imported nested negation", rule: { "!": { "===": [1, 2] } } },
+  { title: "imported age range", rule: { "<=": [18, { var: "user.age" }, 65] } },
+  { title: "conditional without else", rule: { if: [true, "yes"] } },
   { title: "simple comparison", rule: rule.eq(rule.var("user.age"), 21) },
   {
     title: "and / or",

--- a/packages/react-json-logic/src/components/any.tsx
+++ b/packages/react-json-logic/src/components/any.tsx
@@ -30,6 +30,11 @@ function isPlainObject(value: unknown): value is Record<string, JsonLogicValue> 
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function getOperands(value: JsonLogicValue | undefined): JsonLogicValue[] {
+  if (Array.isArray(value)) return value;
+  return value === undefined ? [] : [value];
+}
+
 function deriveState(value: JsonLogicValue | undefined): DerivedState {
   let field = "value";
 
@@ -90,8 +95,7 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
   // Add/remove controls only call this for a selected operator.
   const updateChildArray = (update: (arr: JsonLogicValue[]) => JsonLogicValue[]) => {
     const current = isPlainObject(value) ? value : {};
-    const slot = current[field];
-    const arr = Array.isArray(slot) ? [...slot] : typeof slot === "string" ? [slot] : [];
+    const arr = getOperands(current[field]);
     onChange({ ...current, [field]: update(arr) });
   };
 
@@ -122,9 +126,8 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
     if (field === "value") {
       childValue = value === undefined ? "" : value;
     } else if (isPlainObject(value)) {
-      const slot = value[field];
-      if (Array.isArray(slot)) childValue = slot[index] === undefined ? "" : slot[index];
-      else if (typeof slot === "string" && index === 0) childValue = slot;
+      const operand = getOperands(value[field])[index];
+      childValue = operand === undefined ? "" : operand;
     }
 
     const childOnChange = (val: JsonLogicValue) => onChildValueChange(val, index);

--- a/packages/react-json-logic/src/components/any.tsx
+++ b/packages/react-json-logic/src/components/any.tsx
@@ -119,9 +119,10 @@ export function Any({ parent, value, data = {}, onChange }: Props) {
     updateChildArray((arr) => arr.filter((_, i) => i !== index));
   };
 
-  const renderChild = (childField: FieldType, index: number) => {
-    const isRemovable = selectedOperator ? fields.length > selectedOperator.fieldCount.min : false;
+  const operandCount = isPlainObject(value) ? getOperands(value[field]).length : 0;
+  const isRemovable = selectedOperator ? operandCount > selectedOperator.fieldCount.min : false;
 
+  const renderChild = (childField: FieldType, index: number) => {
     let childValue: JsonLogicValue = "";
     if (field === "value") {
       childValue = value === undefined ? "" : value;

--- a/packages/react-json-logic/src/operators.ts
+++ b/packages/react-json-logic/src/operators.ts
@@ -84,7 +84,7 @@ export const OPERATORS: Operator[] = [
     label: "if",
     fields: ["any", "any", "any"],
     notAvailableUnder: [],
-    fieldCount: { min: 3, max: MAX_VARIADIC - 1 },
+    fieldCount: { min: 2, max: MAX_VARIADIC - 1 },
   },
   {
     type: "Logical",
@@ -133,7 +133,7 @@ export const OPERATORS: Operator[] = [
     label: "<=",
     fields: ["any", "any"],
     notAvailableUnder: [],
-    fieldCount: { min: 2, max: 2 },
+    fieldCount: { min: 2, max: 3 },
   },
   {
     type: "Numeric",
@@ -149,7 +149,7 @@ export const OPERATORS: Operator[] = [
     label: "<",
     fields: ["any", "any"],
     notAvailableUnder: [],
-    fieldCount: { min: 2, max: 2 },
+    fieldCount: { min: 2, max: 3 },
   },
   {
     type: "Numeric",

--- a/packages/react-json-logic/tests/edge-cases.test.tsx
+++ b/packages/react-json-logic/tests/edge-cases.test.tsx
@@ -99,7 +99,7 @@ describe("edge-case validation", () => {
   });
 
   test("walks deeply nested rules and reports all errors", () => {
-    const bad = rule.and({ "===": [1] }, { "<": [1, 2, 3] }, true);
+    const bad = rule.and({ "===": [1] }, { "<": [1, 2, 3, 4] }, true);
     const result = validate(bad);
     if (result.ok) throw new Error("expected nested arity errors");
     expect(result.errors).toHaveLength(2);

--- a/packages/react-json-logic/tests/json-logic-builder.test.tsx
+++ b/packages/react-json-logic/tests/json-logic-builder.test.tsx
@@ -326,6 +326,71 @@ describe("<JsonLogicBuilder /> render paths", () => {
   });
 });
 
+describe("imported operands", () => {
+  test.each([5, false, null, { "===": [1, 2] }])(
+    "preserves shorthand %j when adding and removing a sibling",
+    (operand) => {
+      const onChange = vi.fn();
+      render(<StatefulHost initial={{ "+": operand }} onChange={onChange} />);
+      fireEvent.click(screen.getByRole("button", { name: "Add field" }));
+      expect(onChange).toHaveBeenLastCalledWith({ "+": [operand, ""] });
+      fireEvent.click(screen.getByRole("button", { name: "Remove field 2" }));
+      expect(onChange).toHaveBeenLastCalledWith({ "+": [operand] });
+    },
+  );
+
+  test("renders and edits a numeric shorthand without changing its sibling", () => {
+    const onChange = vi.fn();
+    render(<StatefulHost initial={{ "-": 5 }} onChange={onChange} />);
+    expect(screen.getByRole("spinbutton").getAttribute("value")).toBe("5");
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "2" } });
+    expect(onChange).toHaveBeenLastCalledWith({ "-": [5, "2"] });
+  });
+
+  test("renders boolean and explicit null shorthand, distinct from missing operands", () => {
+    const { container, rerender } = render(
+      <JsonLogicBuilder value={{ "!": false }} onChange={ignoreChange} />,
+    );
+    expect(container.querySelector("[data-rjl-input-boolean]")?.textContent).toBe("false");
+    rerender(<JsonLogicBuilder value={{ "!": null }} onChange={ignoreChange} />);
+    expect(container.querySelector("[data-rjl-input-type-trigger]")?.textContent).toBe("null");
+    expect(screen.queryByRole("textbox")).toBeNull();
+    rerender(<JsonLogicBuilder value={{ "!": [] }} onChange={ignoreChange} />);
+    expect(screen.getByRole("textbox").getAttribute("value")).toBe("");
+  });
+
+  test("renders and edits a nested shorthand", () => {
+    const onChange = vi.fn();
+    render(<StatefulHost initial={{ "!": { "===": [1, 2] } }} onChange={onChange} />);
+    const inputs = screen.getAllByRole("spinbutton");
+    expect(inputs.map((input) => input.getAttribute("value"))).toEqual(["1", "2"]);
+    fireEvent.change(inputs[1]!, { target: { value: "1" } });
+    expect(onChange).toHaveBeenLastCalledWith({ "!": [{ "===": [1, 1] }] });
+    expect(applyLogic(onChange.mock.calls.at(-1)?.[0])).toBe(false);
+  });
+
+  test("edits a conditional consequence without adding an absent else", () => {
+    const onChange = vi.fn();
+    render(<StatefulHost initial={{ if: [true, "yes"] }} onChange={onChange} />);
+    fireEvent.change(screen.getByDisplayValue("yes"), { target: { value: "ok" } });
+    expect(onChange).toHaveBeenLastCalledWith({ if: [true, "ok"] });
+    expect(applyLogic(onChange.mock.calls.at(-1)?.[0])).toBe("ok");
+  });
+
+  test.each(["<", "<="])("edits all three %s range operands", (operator) => {
+    const onChange = vi.fn();
+    render(<StatefulHost initial={{ [operator]: [1, 2, 3] }} onChange={onChange} />);
+    const inputs = screen.getAllByRole("spinbutton");
+    expect(inputs.map((input) => input.getAttribute("value"))).toEqual(["1", "2", "3"]);
+    fireEvent.change(inputs[2]!, { target: { value: "4" } });
+    expect(onChange).toHaveBeenLastCalledWith({ [operator]: [1, 2, 4] });
+    fireEvent.click(screen.getByRole("button", { name: "Remove field 3" }));
+    expect(onChange).toHaveBeenLastCalledWith({ [operator]: [1, 2] });
+    fireEvent.click(screen.getByRole("button", { name: "Add field" }));
+    expect(onChange).toHaveBeenLastCalledWith({ [operator]: [1, 2, ""] });
+  });
+});
+
 describe("<JsonLogicBuilder /> onChange interactions", () => {
   test("addField appends an empty entry through onChange", () => {
     const onChange = vi.fn();

--- a/packages/react-json-logic/tests/json-logic-builder.test.tsx
+++ b/packages/react-json-logic/tests/json-logic-builder.test.tsx
@@ -369,6 +369,18 @@ describe("imported operands", () => {
     expect(applyLogic(onChange.mock.calls.at(-1)?.[0])).toBe(false);
   });
 
+  test("keeps conditional removal at the actual operand minimum", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <JsonLogicBuilder value={{ if: [true, "yes"] }} onChange={onChange} />,
+    );
+    expect(screen.queryByRole("button", { name: /Remove field/ })).toBeNull();
+    rerender(<StatefulHost initial={{ if: [true, "yes", "no"] }} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Remove field 3" }));
+    expect(onChange).toHaveBeenLastCalledWith({ if: [true, "yes"] });
+    expect(screen.queryByRole("button", { name: /Remove field/ })).toBeNull();
+  });
+
   test("edits a conditional consequence without adding an absent else", () => {
     const onChange = vi.fn();
     render(<StatefulHost initial={{ if: [true, "yes"] }} onChange={onChange} />);

--- a/packages/react-json-logic/tests/validator.test.ts
+++ b/packages/react-json-logic/tests/validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vite-plus/test";
-import { validate, type ValidationError } from "../src/index.ts";
+import { applyLogic, validate, type JsonLogicValue, type ValidationError } from "../src/index.ts";
 
 function validationErrors(value: unknown): ValidationError[] {
   const result = validate(value);
@@ -27,9 +27,21 @@ describe("validate", () => {
     expect(errors[0]?.path).toBe("$.===");
   });
 
+  test.each<{ rule: JsonLogicValue; result: unknown }>([
+    { rule: { "<": [1, 2, 3] }, result: true },
+    { rule: { "<": [1, 3, 2] }, result: false },
+    { rule: { "<=": [1, 2, 2] }, result: true },
+    { rule: { "<=": [2, 1, 3] }, result: false },
+    { rule: { if: [true, "yes"] }, result: "yes" },
+    { rule: { if: [false, "yes"] }, result: null },
+  ])("accepts evaluator-supported $rule", ({ rule, result }) => {
+    expect(applyLogic(rule)).toEqual(result);
+    expect(validate(rule)).toEqual({ ok: true });
+  });
+
   test("flags arity above maximum", () => {
-    const errors = validationErrors({ "<": [1, 2, 3] });
-    expect(errors[0]?.message).toMatch(/at most 2/);
+    const errors = validationErrors({ "<": [1, 2, 3, 4] });
+    expect(errors[0]?.message).toMatch(/at most 3/);
   });
 
   test("walks nested rules and reports child errors", () => {


### PR DESCRIPTION
## Problem

Imported scalar and nested operands were hidden and could be discarded during editing. Validation rejected supported three-argument ranges and conditionals without an else.

The workflow used third-party runners in a public repository, including a release runner unsupported by npm trusted publishing.

## Solution

Preserve defined shorthand operands through rendering and controlled updates, including explicit null. Allow three arguments for `<`/`<=` and two for `if`, retaining the existing UI defaults. Removal uses the actual operand count so a two-argument conditional cannot lose a required operand. Add regression coverage and import examples in the demo.

Run verification and publication on GitHub-hosted `ubuntu-latest` runners under the public-repository policy. This also meets the [npm trusted publishing runner requirement](https://docs.npmjs.com/trusted-publishers/).

## Proof

The new regression suite failed 16 cases against the original source. Final `pnpm verify` passes 111 tests, coverage thresholds, library packaging and demo build. React Doctor reports no introduced issues against `origin/main`.

Browser edits preserved these shapes:

```json
{"-": [6]}
{"!": [{"===": [1, 1]}]}
{"<=": [18, {"var": "user.age"}, 20]}
{"if": [true, "ok"]}
```

Evaluation returned `-6`, `false`, `false`, and `"ok"`. The conditional has no Remove controls at two operands; adding a third and removing it by keyboard returns to two without allowing further removal. `actionlint` and offline `zizmor` passed for the workflow.

Keyboard removal retained the first two range operands; the 375×812 view had no document overflow.
